### PR TITLE
default route updated to return 5_days historical data

### DIFF
--- a/src/views.py
+++ b/src/views.py
@@ -26,13 +26,13 @@ def get_all(ticker):
 
         # Determine difference between old/new timestamps
         format = "%H:%M:%S"
-        old_time = old_json['data']['timestamp']
+        old_time = old_json['timestamp']
         new_time = (datetime.utcnow()).strftime(format)
         time_delta = datetime.strptime(
             new_time, format) - datetime.strptime(old_time, format)
 
         # Return new scrape if difference in stamps exceeds 5 secs or new index is requested
-        if abs(time_delta.total_seconds()) >= 5 or old_json['data']['symbol'] != ticker.upper():
+        if abs(time_delta.total_seconds()) >= 5 or old_json['symbol'] != ticker.upper():
 
             # return new current, write new data into json
             print('Returning new scrape')
@@ -46,17 +46,13 @@ def get_all(ticker):
             # Call 5_day historical
             historical = retrieve_historical(ticker, '5_days')
 
-            # Load scrape data and historical data into payload
-            payload = {
-                'data': data,
-                'historical': historical
-            }
+            data['historical'] = historical
 
             # Write payload to json
             with open('data.json', 'w') as data_json:
-                json.dump(payload, data_json)
+                json.dump(data, data_json)
 
-            return payload
+            return data
 
         else:
             # return old data if timestamp difference less than 5 secs
@@ -77,17 +73,13 @@ def get_all(ticker):
         # Call 5_day historical
         historical = retrieve_historical(ticker, '5_days')
 
-        # Load scrape data and historical data into payload
-        payload = {
-            'data': data,
-            'historical': historical
-        }
+        data['historical'] = historical
 
         # Write scrape to new json
         with open('data.json', 'w') as data_json:
-            json.dump(payload, data_json)
+            json.dump(data, data_json)
 
-        return payload
+        return data
 
 
 @app.route('/v1/<ticker>/historical/<data_range>')

--- a/src/views.py
+++ b/src/views.py
@@ -21,8 +21,8 @@ def get_all(ticker):
     # Detect if json exists, create new json if none found
     try:
         # Unpack old json to parse time
-        with open('data.json', 'r') as file:
-            old_json = json.load(file)
+        with open('data.json', 'r') as data_json:
+            old_json = json.load(data_json)
 
         # Determine difference between old/new timestamps
         format = "%H:%M:%S"
@@ -53,8 +53,8 @@ def get_all(ticker):
             }
 
             # Write payload to json
-            with open('data.json', 'w') as file:
-                json.dump(payload, file)
+            with open('data.json', 'w') as data_json:
+                json.dump(payload, data_json)
 
             return payload
 
@@ -84,8 +84,8 @@ def get_all(ticker):
         }
 
         # Write scrape to new json
-        with open('data.json', 'w') as stock_json:
-            json.dump(payload, stock_json)
+        with open('data.json', 'w') as data_json:
+            json.dump(payload, data_json)
 
         return payload
 


### PR DESCRIPTION
**IMPORTANT: Returned json now stores scraped data under 'data' key and historical data under 'historical' key**

```python
OLD FORMAT
{
    "current": 2128.31, 
    "name": "Alphabet Inc."
}
```

```python
NEW FORMAT
{
  "data": {
    "current": 2128.31, 
    "name": "Alphabet Inc.", 
  }, 
  "historical": [
    {
      "close": 2095.89, 
      "date": "2021-02-11"
    }, 
    {
      "close": 2104.11, 
      "date": "2021-02-12"
    }
  ]
}
```

New keys must be prefixed to old data indexing!